### PR TITLE
fix: カレンダーセルクリック時のAddGigModal日付表示を修正

### DIFF
--- a/gigdig/components/AddGigModal.vue
+++ b/gigdig/components/AddGigModal.vue
@@ -1,9 +1,12 @@
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, nextTick } from 'vue'
 
 const props = defineProps({
   resetArtistInput: Boolean,
-
+  selectedDate: {
+    type: String,
+    default: '',
+  },
   x: {
     type: Number,
     default: 0,
@@ -34,6 +37,19 @@ watch(() => props.resetArtistInput, (newVal) => {
 watch(() => props.visible, (newVal) => {
   if (!newVal) {
     selectedArtist.value = null;
+  }
+});
+
+// selectedDateが変わったときにdate inputに値を設定
+watch(() => props.selectedDate, (newDate) => {
+  if (newDate) {
+    // nextTickを使ってDOMが更新された後に値を設定
+    nextTick(() => {
+      const dateInput = document.getElementById('gig-date');
+      if (dateInput) {
+        dateInput.value = newDate;
+      }
+    });
   }
 });
 

--- a/gigdig/pages/index.vue
+++ b/gigdig/pages/index.vue
@@ -214,6 +214,7 @@ const hideAddGigModal = () => {
       :visible="showAddGigModal"
       :x="addGigModalX"
       :y="addGigModalY"
+      :selectedDate="selectedDate"
       @closeModal="hideAddGigModal"
       @submit="storeGigInfo"
       @artistSelected="handleSelectedArtist"


### PR DESCRIPTION
<!--To GitHub Copilot(Reviewer), Please review this PR in Japanese. -->

# Pull Request

## 概要
カレンダーのセルをクリックしたときにAddGigModalのDate欄に表示される日付が1日遅れていた問題を修正しました。

## 変更内容
- [x] AddGigModal.vueにselectedDate propsを追加し、選択された日付を自動設定する機能を実装
- [x] index.vueでAddGigModalにselectedDateプロパティを渡すよう修正
- [x] 日付入力フィールドに正しい日付が表示されるよう修正

## 変更の種類
- [x] 🐛 バグ修正
- [ ] ✨ 新機能
- [ ] 💄 UI/UXの改善
- [ ] ♻️ リファクタリング
- [ ] 📝 ドキュメント更新
- [ ] 🔧 設定ファイルの変更
- [ ] 🧪 テストの追加/修正
- [ ] 🚀 パフォーマンス改善
- [ ] 🔒 セキュリティ関連

## テスト
- [x] 手動テストを実施
- [ ] 自動テストを追加/更新
- [x] 既存のテストが通ることを確認

## 関連Issue
Closes #37

## チェックリスト
- [x] コードが設計ルール（DESIGN_RULE.md）に従っている
- [x] Lintエラーがない
- [x] 不要なコメントやデバッグコードを削除した
- [x] ブラウザでの動作確認を実施した
- [x] 必要に応じてドキュメントを更新した

## 補足事項
### 修正内容の詳細
1. **AddGigModal.vue**: 
   - selectedDate propsを追加
   - 選択された日付が変更されたときにdate inputフィールドに自動設定するwatcherを追加
   - nextTickを使用してDOMの更新後に値を設定

2. **index.vue**: 
   - AddGigModalにselectedDateプロパティを渡すよう修正
   - 既存のhandleShowAddGigModal関数は適切に実装されていたが、テンプレートでpropsが渡されていなかった

### 根本原因
Calendar.vueから発行されるshow-add-gig-modalイベントには正しい日付が含まれており、index.vueのhandleShowAddGigModal関数でも適切に処理されていました。しかし、AddGigModalコンポーネントにselectedDateプロパティが渡されていなかったため、モーダル内のwatcherが動作せず、日付の自動設定が行われていませんでした。

### 動作確認
- カレンダーのセルをクリックすると、AddGigModalのDate欄にクリックした日付が正しく表示されることを確認
- DBに保存される日付とgig-labelに表示される日付が一致することを確認
- GigDetailModalでも正しい日付が表示されることを確認